### PR TITLE
fix: dark foreground color being too dark

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,7 +87,7 @@
 	--popover: oklch(0.21 0.006 285.885);
 	--popover-foreground: oklch(0.985 0 0);
 	--primary: oklch(0.546 0.245 262.881);
-	--primary-foreground: oklch(0.379 0.146 265.522);
+	--primary-foreground: oklch(0.97 0.014 254.604);
 	--secondary: oklch(0.274 0.006 286.033);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.274 0.006 286.033);


### PR DESCRIPTION
Noticed on dark mode the icon and badge text was a bit to dark to be considered readable

Before:
<img width="1491" height="341" alt="image" src="https://github.com/user-attachments/assets/fb6f5722-b742-4965-9267-b30a44ef2c1d" />

After:
<img width="1484" height="317" alt="image" src="https://github.com/user-attachments/assets/e855ac38-d13b-499a-a852-4e91cbdc5448" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the primary foreground color in the dark theme, refreshing the appearance of text and key UI elements in dark mode.
  * Visual-only change; no impact on functionality or interactions.
  * Applies across components that use the primary foreground styling in dark mode.
  * No changes to other theme colors or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->